### PR TITLE
remove source (*.ts files) to reduce source size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,3 +23,6 @@ coverage
 
 # github
 .github
+
+# source
+src


### PR DESCRIPTION
#### `*.ts` files will be removed to reduce package size. Additionally, it's unnecessary to download this file from released package.