### PR TITLE
2.0.2

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-label: 'stale'

--- a/.npmignore
+++ b/.npmignore
@@ -10,19 +10,18 @@ tsconfig.*
 # Coverage directory used by tools like istanbul
 coverage
 
+# resource files
+.*rc*
+
 # nyc test coverage
-.nycrc
 .nyc_output
 
-# prettier
-.prettierrc.yml
-
 # eslint
-.eslintrc.yml
 .eslintignore
 
 # github
 .github
+.dependabot
 
 # source
 src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Changelog
-
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
-and all changes are documented on Github [Releases](https://github.com/hckhanh/read-vn-number/releases) page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [2.0.2](https://github.com/hckhanh/read-vn-number/compare/v1.3.2...v2.0.2) (2020-05-28)
+
+
+### Dependencies
+
+* **deps:** bump @types/node from 13.13.5 to 14.0.5 ([#46](https://github.com/hckhanh/read-vn-number/issues/46)) ([54f9e70](https://github.com/hckhanh/read-vn-number/commit/54f9e70bad9300cc1c2e3b513ac519bc8711b844))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin from 2.31.0 to 2.34.0 ([#41](https://github.com/hckhanh/read-vn-number/issues/41)) ([3f94cf1](https://github.com/hckhanh/read-vn-number/commit/3f94cf14e0e9132fd3752142569a2397194fdccb))
+* **deps-dev:** bump @typescript-eslint/parser from 2.31.0 to 2.34.0 ([#42](https://github.com/hckhanh/read-vn-number/issues/42)) ([cc2b490](https://github.com/hckhanh/read-vn-number/commit/cc2b490e1750f0e9a2d4f3062cfc3037a49a6c70))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "read-vn-number",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "read-vn-number",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Read Vietnamese number like a Vietnamese",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
* Bump typescript from 3.8.3 to 3.9.3  dependencies
* Bump @types/node from 13.13.5 to 14.0.5  dependencies
* Bump @typescript-eslint/parser from 2.31.0 to 2.34.0  dependencies
* Bump @typescript-eslint/eslint-plugin from 2.31.0 to 2.34.0  dependencies